### PR TITLE
A new way to auth without sessionName field

### DIFF
--- a/src/Synology.Api.Client/ApiDescription/DefaultApisInfo.cs
+++ b/src/Synology.Api.Client/ApiDescription/DefaultApisInfo.cs
@@ -17,9 +17,8 @@ namespace Synology.Api.Client.Apis
 
             AuthApi = new ApiInfo(
                 ApiNames.AuthApiName,
-                "auth.cgi",
-                3,
-                FileStationSessionName);
+                "entry.cgi",
+                6);
 
             DownloadStationTaskApi = new ApiInfo(
                 ApiNames.DownloadStationTaskApiName,


### PR DESCRIPTION
I changed AuthApi  field with new path, version and without sessionName (from example this [doc](https://global.download.synology.com/download/Document/Software/DeveloperGuide/Os/DSM/All/enu/DSM_Login_Web_API_Guide_enu.pdf)). This version works with my NAS with DSM v7. I think this way should be more versatile for works with different API (FileStation, DownloadStation).

New AuthApi field:
```csharp
AuthApi = new ApiInfo(
    ApiNames.AuthApiName,
    "entry.cgi",
    6);
```