### PR TITLE
Remove `Flurl` and `Newtonsoft.Json`

### DIFF
--- a/src/Synology.Api.Client.Integration.Tests/Synology.Api.Client.Integration.Tests.csproj
+++ b/src/Synology.Api.Client.Integration.Tests/Synology.Api.Client.Integration.Tests.csproj
@@ -1,25 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions" Version="6.10.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Synology.Api.Client\Synology.Api.Client.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Synology.Api.Client\Synology.Api.Client.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Synology.Api.Client.Tests/AuthApiTests.cs
+++ b/src/Synology.Api.Client.Tests/AuthApiTests.cs
@@ -29,7 +29,8 @@ namespace Synology.Api.Client.Tests
             _fixture = new Fixture();
             _apiInfo = _synologyFixture.ApisInfo.AuthApi;
             _mockHtttp = new MockHttpMessageHandler();
-            _baseUriWithApiPath = new Uri(_synologyFixture.BaseUri, _apiInfo.Path);
+
+            _baseUriWithApiPath = _synologyFixture.GetBaseUriWithPath(_apiInfo.Path);
         }
 
         public void Dispose()

--- a/src/Synology.Api.Client.Tests/AuthApiTests.cs
+++ b/src/Synology.Api.Client.Tests/AuthApiTests.cs
@@ -52,7 +52,7 @@ namespace Synology.Api.Client.Tests
         #endregion
 
         [Fact]
-        public async void Login_CallsCorrectUrl()
+        public async void Login_ShouldCallCorrectUrl()
         {
             // Arrange
             var username = _fixture.Create<string>();

--- a/src/Synology.Api.Client.Tests/Extensions/StringArrayExtensionsTests.cs
+++ b/src/Synology.Api.Client.Tests/Extensions/StringArrayExtensionsTests.cs
@@ -23,7 +23,7 @@ namespace Synology.Api.Client.Tests.Extensions
         public void StringArrayExtensions_EmptyArray_ReturnEmptyBrackets()
         {
             // arrange
-            var words = new string[0];
+            var words = System.Array.Empty<string>();
 
             // act
             var result = words.ToCommaSeparatedAroundBrackets();

--- a/src/Synology.Api.Client.Tests/FileStationApiUploadEndpointTests.cs
+++ b/src/Synology.Api.Client.Tests/FileStationApiUploadEndpointTests.cs
@@ -268,16 +268,20 @@ namespace Synology.Api.Client.Tests
             // Arrange
             var apiInfo = new ApiInfo(_apiInfo.Name, _apiInfo.Path, apiVersion, _apiInfo.SessionName);
 
-            var expectedRequestContentApiVersion = $"""
-                Content-Disposition: form-data; name="version"
+            var expectedRequestContentApiVersion = $"Content-Disposition: form-data; name=\"version\"{Environment.NewLine}{Environment.NewLine}{apiVersion}";
+            var expectedRequestContentOverwrite = $"Content-Disposition: form-data; name=\"overwrite\"{Environment.NewLine}{Environment.NewLine}{overwriteValue}";
 
-                {apiVersion}
-                """;
-            var expectedRequestContentOverwrite = $"""
-                Content-Disposition: form-data; name="overwrite"
+            //uses raw string literals, but seems to break tests in CI
+            //var expectedRequestContentApiVersion = $"""
+            //    Content-Disposition: form-data; name="version"
 
-                {overwriteValue}
-                """;
+            //    {apiVersion}
+            //    """;
+            //var expectedRequestContentOverwrite = $"""
+            //    Content-Disposition: form-data; name="overwrite"
+
+            //    {overwriteValue}
+            //    """;
 
             var expectedResponse = new ApiResponse<FileStationUploadResponse>
             {

--- a/src/Synology.Api.Client.Tests/FileStationApiUploadEndpointTests.cs
+++ b/src/Synology.Api.Client.Tests/FileStationApiUploadEndpointTests.cs
@@ -40,7 +40,7 @@ namespace Synology.Api.Client.Tests
             _fixture = new Fixture();
             _apiInfo = _synologyFixture.ApisInfo.FileStationUploadApi;
             _mockHtttp = new MockHttpMessageHandler();
-            _baseUriWithApiPath = new Uri(_synologyFixture.BaseUri, _apiInfo.Path);
+            _baseUriWithApiPath = _synologyFixture.GetBaseUriWithPath(_apiInfo.Path);
             _session = new SynologySession(_fixture.Create<string>());
             _destination = _fixture.Create<string>();
 

--- a/src/Synology.Api.Client.Tests/FileStationApiUploadEndpointTests.cs
+++ b/src/Synology.Api.Client.Tests/FileStationApiUploadEndpointTests.cs
@@ -1,107 +1,107 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO.Abstractions.TestingHelpers;
-using System.Threading.Tasks;
-using AutoFixture;
-using FluentAssertions;
-using Flurl.Http.Testing;
-using Synology.Api.Client.ApiDescription;
-using Synology.Api.Client.Apis.FileStation.Upload;
-using Synology.Api.Client.Apis.FileStation.Upload.Models;
-using Synology.Api.Client.Errors;
-using Synology.Api.Client.Exceptions;
-using Synology.Api.Client.Session;
-using Synology.Api.Client.Shared.Models;
-using Synology.Api.Client.Tests.Fixtures;
-using Xunit;
+﻿//using System;
+//using System.Collections.Generic;
+//using System.IO.Abstractions.TestingHelpers;
+//using System.Threading.Tasks;
+//using AutoFixture;
+//using FluentAssertions;
+//using Flurl.Http.Testing;
+//using Synology.Api.Client.ApiDescription;
+//using Synology.Api.Client.Apis.FileStation.Upload;
+//using Synology.Api.Client.Apis.FileStation.Upload.Models;
+//using Synology.Api.Client.Errors;
+//using Synology.Api.Client.Exceptions;
+//using Synology.Api.Client.Session;
+//using Synology.Api.Client.Shared.Models;
+//using Synology.Api.Client.Tests.Fixtures;
+//using Xunit;
 
-namespace Synology.Api.Client.Tests
-{
-    public class FileStationApiUploadEndpointTests : IClassFixture<SynologyFixture>, IDisposable
-    {
-        private readonly SynologyFixture _synologyFixture;
-        private readonly Fixture _fixture;
-        private readonly HttpTest _httpTest;
-        private readonly FileStationUploadEndpoint _fileStationUploadEndpoint;
-        private readonly IApiInfo _apiInfo;
+//namespace Synology.Api.Client.Tests
+//{
+//    public class FileStationApiUploadEndpointTests : IClassFixture<SynologyFixture>, IDisposable
+//    {
+//        private readonly SynologyFixture _synologyFixture;
+//        private readonly Fixture _fixture;
+//        private readonly HttpTest _httpTest;
+//        private readonly FileStationUploadEndpoint _fileStationUploadEndpoint;
+//        private readonly IApiInfo _apiInfo;
 
-        private const string TestFilePath = @"c:\myfile.txt";
+//        private const string TestFilePath = @"c:\myfile.txt";
 
-        public FileStationApiUploadEndpointTests(SynologyFixture synologyFixture)
-        {
-            _fixture = new Fixture();
-            _httpTest = new HttpTest();
-            _synologyFixture = synologyFixture;
-            _apiInfo = _synologyFixture.ApisInfo.FileStationUploadApi;
+//        public FileStationApiUploadEndpointTests(SynologyFixture synologyFixture)
+//        {
+//            _fixture = new Fixture();
+//            _httpTest = new HttpTest();
+//            _synologyFixture = synologyFixture;
+//            _apiInfo = _synologyFixture.ApisInfo.FileStationUploadApi;
 
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                { TestFilePath, new MockFileData("Test file") }
-            });
+//            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+//            {
+//                { TestFilePath, new MockFileData("Test file") }
+//            });
 
-            _fileStationUploadEndpoint = new FileStationUploadEndpoint(
-                synologyFixture.SynologyHttpClient,
-                _apiInfo,
-                new SynologySession(_fixture.Create<string>()),
-                fileSystem);
-        }
+//            _fileStationUploadEndpoint = new FileStationUploadEndpoint(
+//                synologyFixture.SynologyHttpClient,
+//                _apiInfo,
+//                new SynologySession(_fixture.Create<string>()),
+//                fileSystem);
+//        }
 
-        [Fact]
-        public async void UploadEndpoint_Upload_CallsCorrectUrl()
-        {
-            // arrange
-            var destination = _fixture.Create<string>();
+//        [Fact]
+//        public async void UploadEndpoint_Upload_CallsCorrectUrl()
+//        {
+//            // arrange
+//            var destination = _fixture.Create<string>();
 
-            var expectedResponse = new ApiResponse<FileStationUploadResponse>
-            {
-                Success = true,
-                Data = _fixture.Create<FileStationUploadResponse>()
-            };
+//            var expectedResponse = new ApiResponse<FileStationUploadResponse>
+//            {
+//                Success = true,
+//                Data = _fixture.Create<FileStationUploadResponse>()
+//            };
 
-            _httpTest.RespondWithJson(expectedResponse);
+//            _httpTest.RespondWithJson(expectedResponse);
 
-            // act
-            await _fileStationUploadEndpoint.UploadAsync(TestFilePath, destination, true);
+//            // act
+//            await _fileStationUploadEndpoint.UploadAsync(TestFilePath, destination, true);
 
-            // assert
-            _httpTest
-                .ShouldHaveCalled($"{_synologyFixture.BaseUrl}/{_apiInfo.Path}*");
-        }
+//            // assert
+//            _httpTest
+//                .ShouldHaveCalled($"{_synologyFixture.BaseUrl}/{_apiInfo.Path}*");
+//        }
 
-        [Fact]
-        public void UploadEndpoint_UploadFilePathNotFound_DisplaysCorrectError()
-        {
-            // arrange
-            var destination = _fixture.Create<string>();
-            var notFoundErrorCode = 408;
+//        [Fact]
+//        public void UploadEndpoint_UploadFilePathNotFound_DisplaysCorrectError()
+//        {
+//            // arrange
+//            var destination = _fixture.Create<string>();
+//            var notFoundErrorCode = 408;
 
-            var expectedResponse = new ApiResponse<FileStationUploadResponse>
-            {
-                Success = false,
-                Error = new Error
-                {
-                    Code = notFoundErrorCode
-                }
-            };
+//            var expectedResponse = new ApiResponse<FileStationUploadResponse>
+//            {
+//                Success = false,
+//                Error = new Error
+//                {
+//                    Code = notFoundErrorCode
+//                }
+//            };
 
-            _httpTest.RespondWithJson(expectedResponse);
+//            _httpTest.RespondWithJson(expectedResponse);
 
-            // act
-            Func<Task> action = async () => await _fileStationUploadEndpoint.UploadAsync(TestFilePath, destination, true);
+//            // act
+//            Func<Task> action = async () => await _fileStationUploadEndpoint.UploadAsync(TestFilePath, destination, true);
 
-            // assert
-            action
-                .Should()
-                .ThrowAsync<SynologyApiException>().Result
-                .And
-                .ErrorDescription
-                .Should()
-                .BeEquivalentTo(ErrorMessages.FileStationApiErrors.GetValueOrDefault(notFoundErrorCode));
-        }
+//            // assert
+//            action
+//                .Should()
+//                .ThrowAsync<SynologyApiException>().Result
+//                .And
+//                .ErrorDescription
+//                .Should()
+//                .BeEquivalentTo(ErrorMessages.FileStationApiErrors.GetValueOrDefault(notFoundErrorCode));
+//        }
 
-        public void Dispose()
-        {
-            _httpTest.Dispose();
-        }
-    }
-}
+//        public void Dispose()
+//        {
+//            _httpTest.Dispose();
+//        }
+//    }
+//}

--- a/src/Synology.Api.Client.Tests/FileStationApiUploadEndpointTests.cs
+++ b/src/Synology.Api.Client.Tests/FileStationApiUploadEndpointTests.cs
@@ -268,8 +268,8 @@ namespace Synology.Api.Client.Tests
             // Arrange
             var apiInfo = new ApiInfo(_apiInfo.Name, _apiInfo.Path, apiVersion, _apiInfo.SessionName);
 
-            var expectedRequestContentApiVersion = $"Content-Disposition: form-data; name=\"version\"{Environment.NewLine}{Environment.NewLine}{apiVersion}";
-            var expectedRequestContentOverwrite = $"Content-Disposition: form-data; name=\"overwrite\"{Environment.NewLine}{Environment.NewLine}{overwriteValue}";
+            var expectedRequestContentApiVersion = $"Content-Disposition: form-data; name=\"version\"\r\n\r\n{apiVersion}";//do not use Environment.NewLine because of macOS
+            var expectedRequestContentOverwrite = $"Content-Disposition: form-data; name=\"overwrite\"\r\n\r\n{overwriteValue}";
 
             //uses raw string literals, but seems to break tests in CI
             //var expectedRequestContentApiVersion = $"""

--- a/src/Synology.Api.Client.Tests/Fixtures/SynologyFixture.cs
+++ b/src/Synology.Api.Client.Tests/Fixtures/SynologyFixture.cs
@@ -15,5 +15,10 @@ namespace Synology.Api.Client.Tests.Fixtures
         public string BaseUrl => "http://dsm-url.com/webapi";
 
         public Uri BaseUri => new Uri(BaseUrl);
+
+        public Uri GetBaseUriWithPath(string apiPath)
+        {
+            return new Uri(BaseUrl.TrimEnd('/') + "/" + apiPath.TrimStart('/'));
+        }
     }
 }

--- a/src/Synology.Api.Client.Tests/Fixtures/SynologyFixture.cs
+++ b/src/Synology.Api.Client.Tests/Fixtures/SynologyFixture.cs
@@ -1,4 +1,4 @@
-﻿using Flurl.Http;
+﻿using System;
 using Synology.Api.Client.ApiDescription;
 
 namespace Synology.Api.Client.Tests.Fixtures
@@ -7,14 +7,13 @@ namespace Synology.Api.Client.Tests.Fixtures
     {
         public SynologyFixture()
         {
-            SynologyHttpClient = new SynologyHttpClient(new FlurlClient(BaseUrl));
             ApisInfo = new DefaultApisInfo();
         }
-
-        public ISynologyHttpClient SynologyHttpClient { get; }
 
         public IApisInfo ApisInfo { get; }
 
         public string BaseUrl => "http://dsm-url.com/webapi";
+
+        public Uri BaseUri => new Uri(BaseUrl);
     }
 }

--- a/src/Synology.Api.Client.Tests/Synology.Api.Client.Tests.csproj
+++ b/src/Synology.Api.Client.Tests/Synology.Api.Client.Tests.csproj
@@ -14,11 +14,10 @@
 </PackageReference>
     <PackageReference Include="coverlet.collector" Version="3.2.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
-</PackageReference>
-    <PackageReference Include="Flurl.Http" Version="3.2.4" />
+</PackageReference>    
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="17.2.3" />
+	<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.1.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Synology.Api.Client.Tests/Synology.Api.Client.Tests.csproj
+++ b/src/Synology.Api.Client.Tests/Synology.Api.Client.Tests.csproj
@@ -1,27 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>    
-    <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-	<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.1.14" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="AutoFixture" Version="4.17.0" />
+		<PackageReference Include="FluentAssertions" Version="6.10.0" />
+		<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="19.1.18" />
+		<PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Synology.Api.Client\Synology.Api.Client.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Synology.Api.Client\Synology.Api.Client.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Synology.Api.Client.Tests/Synology.Api.Client.Tests.csproj
+++ b/src/Synology.Api.Client.Tests/Synology.Api.Client.Tests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-
+		<LangVersion>latest</LangVersion>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 

--- a/src/Synology.Api.Client.Tests/SynologyHttpClientTests.cs
+++ b/src/Synology.Api.Client.Tests/SynologyHttpClientTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+using Synology.Api.Client.ApiDescription;
+using Synology.Api.Client.Shared.Models;
+using Synology.Api.Client.Tests.Fixtures;
+using Xunit;
+
+namespace Synology.Api.Client.Tests
+{
+    public class SynologyHttpClientTests : IClassFixture<SynologyFixture>, IDisposable
+    {
+        private readonly SynologyFixture _synologyFixture;
+        private readonly Fixture _fixture;
+        private readonly IApiInfo _apiInfo;
+        private readonly MockHttpMessageHandler _mockHtttp;
+        private readonly Uri _baseUriWithApiPath;
+
+        public SynologyHttpClientTests(SynologyFixture synologyFixture)
+        {
+            _synologyFixture = synologyFixture;
+            _fixture = new Fixture();
+            _apiInfo = _synologyFixture.ApisInfo.InfoApi;
+            _mockHtttp = new MockHttpMessageHandler();
+            _baseUriWithApiPath = new Uri(_synologyFixture.BaseUri, _apiInfo.Path);
+        }
+
+        public void Dispose()
+        {
+            _mockHtttp.Dispose();
+        }
+
+        [Fact]
+        public async Task GetAsync_ShouldCallCorrectUri()
+        {
+            // Arrange
+            var expectedPath = _synologyFixture.BaseUrl.TrimEnd('/') + '/' + _apiInfo.Path;
+
+            var expectedResponse = new BaseApiResponse
+            {
+                Success = true
+            };
+
+            //expect certain request to server
+            var request = _mockHtttp.Expect(System.Net.Http.HttpMethod.Get, expectedPath)
+                .Respond(HttpStatusCode.OK, JsonContent.Create(expectedResponse));
+
+            var httpClient = _mockHtttp.ToHttpClient();
+            httpClient.BaseAddress = _synologyFixture.BaseUri;
+
+            ISynologyHttpClient synologyHttpclient = new SynologyHttpClient(httpClient);
+
+            // Act
+            var result = await synologyHttpclient.GetAsync<BaseApiResponse>(_apiInfo, "apiMethod", new Dictionary<string, string>());
+
+            // Assert
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Fact]
+        public async Task PostAsync_ShouldCallCorrectUri()
+        {
+            // Arrange
+            var expectedPath = _synologyFixture.BaseUrl.TrimEnd('/') + '/' + _apiInfo.Path;
+
+            var expectedResponse = new BaseApiResponse
+            {
+                Success = true
+            };
+
+            //expect certain request to server
+            var request = _mockHtttp.Expect(System.Net.Http.HttpMethod.Post, expectedPath)
+                .Respond(HttpStatusCode.OK, JsonContent.Create(expectedResponse));
+
+            var httpClient = _mockHtttp.ToHttpClient();
+            httpClient.BaseAddress = _synologyFixture.BaseUri;
+
+            ISynologyHttpClient synologyHttpclient = new SynologyHttpClient(httpClient);
+
+            // Act
+            var result = await synologyHttpclient.PostAsync<BaseApiResponse>(_apiInfo, "apiMethod", null);
+
+            // Assert
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+}

--- a/src/Synology.Api.Client/ApiDescription/DefaultApisInfo.cs
+++ b/src/Synology.Api.Client/ApiDescription/DefaultApisInfo.cs
@@ -20,8 +20,8 @@ namespace Synology.Api.Client.ApiDescription
             return new DefaultApisInfo
             {
                 AuthApi = { Path = infoQueryResponse.AuthApi.Path },
-                DownloadStationTaskApi = { Path = infoQueryResponse.DownloadStationTaskApi.Path },
-                FileStationCopyMoveApi ={ Path = infoQueryResponse.FileStationCopyMoveApi.Path },
+                DownloadStationTaskApi = { Path = infoQueryResponse.DownloadStationTaskApi?.Path },
+                FileStationCopyMoveApi = { Path = infoQueryResponse.FileStationCopyMoveApi.Path },
                 FileStationCreateFolderApi = { Path = infoQueryResponse.FileStationCreateFolderApi.Path },
                 FileStationExtractApi = { Path = infoQueryResponse.FileStationExtractApi.Path },
                 FileStationListApi = { Path = infoQueryResponse.FileStationListApi.Path },

--- a/src/Synology.Api.Client/Apis/Auth/AuthApi.cs
+++ b/src/Synology.Api.Client/Apis/Auth/AuthApi.cs
@@ -43,6 +43,11 @@ namespace Synology.Api.Client.Apis.Auth
 
         public Task<BaseApiResponse> LogoutAsync(string sid)
         {
+            if (string.IsNullOrWhiteSpace(sid))
+            {
+                throw new ArgumentNullException(nameof(sid));
+            }
+
             return _synologyHttpClient.GetAsync<BaseApiResponse>(_apiInfo, "logout", new Dictionary<string, string> { { "_sid", sid } });
         }
     }

--- a/src/Synology.Api.Client/Apis/Auth/AuthApi.cs
+++ b/src/Synology.Api.Client/Apis/Auth/AuthApi.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Synology.Api.Client.Apis.Auth.Models;
 using Synology.Api.Client.ApiDescription;
+using Synology.Api.Client.Apis.Auth.Models;
 using Synology.Api.Client.Shared.Models;
 
 namespace Synology.Api.Client.Apis.Auth
@@ -29,12 +30,12 @@ namespace Synology.Api.Client.Apis.Auth
                 throw new ArgumentNullException(nameof(password));
             }
 
-            var queryParams = new
+            var queryParams = new Dictionary<string, string>
             {
-                account = username,
-                passwd = password,
-                format = "sid",
-                otp_code = otpCode
+                { "account", username },
+                { "passwd", password },
+                { "format", "sid" },
+                { "otp_code", otpCode }
             };
 
             return _synologyHttpClient.GetAsync<LoginResponse>(_apiInfo, "login", queryParams);
@@ -42,7 +43,7 @@ namespace Synology.Api.Client.Apis.Auth
 
         public Task<BaseApiResponse> LogoutAsync(string sid)
         {
-            return _synologyHttpClient.GetAsync<BaseApiResponse>(_apiInfo, "logout", new { _sid = sid });
+            return _synologyHttpClient.GetAsync<BaseApiResponse>(_apiInfo, "logout", new Dictionary<string, string> { { "_sid", sid } });
         }
     }
 }

--- a/src/Synology.Api.Client/Apis/Auth/Models/LoginResponse.cs
+++ b/src/Synology.Api.Client/Apis/Auth/Models/LoginResponse.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.Auth.Models
 {
     public class LoginResponse
     {
-        [JsonProperty("is_portal_port")]
+        [JsonPropertyName("is_portal_port")]
         public bool IsPortalPort { get; set; }
 
         public string Sid { get; set; }

--- a/src/Synology.Api.Client/Apis/DownloadStation/Task/DownloadStationTaskEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/DownloadStation/Task/DownloadStationTaskEndpoint.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Synology.Api.Client.ApiDescription;
 using Synology.Api.Client.Apis.DownloadStation.Task.Models;
 using Synology.Api.Client.Session;
@@ -20,9 +21,9 @@ namespace Synology.Api.Client.Apis.DownloadStation.Task
 
         public Task<DownloadStationTaskListResponse> ListAsync()
         {
-            var queryParams = new
+            var queryParams = new Dictionary<string, string>
             {
-                additional = "detail,file"
+                { "additional",  "detail,file" }
             };
 
             return _synologyHttpClient.GetAsync<DownloadStationTaskListResponse>(_apiInfo, "list", queryParams, _session);

--- a/src/Synology.Api.Client/Apis/DownloadStation/Task/Models/DownloadStationTask.cs
+++ b/src/Synology.Api.Client/Apis/DownloadStation/Task/Models/DownloadStationTask.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.DownloadStation.Task.Models
 {
@@ -16,7 +16,7 @@ namespace Synology.Api.Client.Apis.DownloadStation.Task.Models
 
         public string Status { get; set; }
 
-        [JsonProperty("status_extra")]
+        [JsonPropertyName("status_extra")]
         public DownloadStationTaskStatusExtra StatusExtra { get; set; }
 
         public DownloadStationTaskAdditional Additional { get; set; }

--- a/src/Synology.Api.Client/Apis/DownloadStation/Task/Models/DownloadStationTaskDetail.cs
+++ b/src/Synology.Api.Client/Apis/DownloadStation/Task/Models/DownloadStationTaskDetail.cs
@@ -1,46 +1,46 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.DownloadStation.Task.Models
 {
     public class DownloadStationTaskDetail
     {
-        [JsonProperty("completed_time")]
+        [JsonPropertyName("completed_time")]
         public long CompletedTime { get; set; }
 
-        [JsonProperty("connected_leechers")]
+        [JsonPropertyName("connected_leechers")]
         public long ConnectedLeechers { get; set; }
 
-        [JsonProperty("connected_peers")]
+        [JsonPropertyName("connected_peers")]
         public long ConnectedPeers { get; set; }
 
-        [JsonProperty("connected_seeders")]
+        [JsonPropertyName("connected_seeders")]
         public long ConnectedSeeders { get; set; }
 
-        [JsonProperty("create_time")]
+        [JsonPropertyName("create_time")]
         public long CreateTime { get; set; }
 
         public string Destination { get; set; }
 
-        [JsonProperty("seedelapsed")]
+        [JsonPropertyName("seedelapsed")]
         public long SeedElapsed { get; set; }
 
-        [JsonProperty("started_time")]
+        [JsonPropertyName("started_time")]
         public long StartedTime { get; set; }
 
-        [JsonProperty("total_peers")]
+        [JsonPropertyName("total_peers")]
         public long TotalPeers { get; set; }
 
-        [JsonProperty("total_pieces")]
+        [JsonPropertyName("total_pieces")]
         public long TotalPieces { get; set; }
 
-        [JsonProperty("unzip_password")]
+        [JsonPropertyName("unzip_password")]
         public string UnzipPassword { get; set; }
 
         public string Uri { get; set; }
 
         public string Priority { get; set; }
 
-        [JsonProperty("waiting_seconds")]
+        [JsonPropertyName("waiting_seconds")]
         public long WaitingSeconds { get; set; }
     }
 }

--- a/src/Synology.Api.Client/Apis/DownloadStation/Task/Models/DownloadStationTaskFile.cs
+++ b/src/Synology.Api.Client/Apis/DownloadStation/Task/Models/DownloadStationTaskFile.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.DownloadStation.Task.Models
 {
@@ -12,7 +12,7 @@ namespace Synology.Api.Client.Apis.DownloadStation.Task.Models
 
         public long Size { get; set; }
 
-        [JsonProperty("size_downloaded")]
+        [JsonPropertyName("size_downloaded")]
         public long SizeDownloaded { get; set; }
 
         public bool Wanted { get; set; }

--- a/src/Synology.Api.Client/Apis/DownloadStation/Task/Models/DownloadStationTaskStatusExtra.cs
+++ b/src/Synology.Api.Client/Apis/DownloadStation/Task/Models/DownloadStationTaskStatusExtra.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.DownloadStation.Task.Models
 {
     public class DownloadStationTaskStatusExtra
     {
-        [JsonProperty("error_detail")]
+        [JsonPropertyName("error_detail")]
         public string ErrorDetail { get; set; }
     }
 }

--- a/src/Synology.Api.Client/Apis/FileStation/CopyMove/FileStationCopyMoveEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/CopyMove/FileStationCopyMoveEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using System.Threading.Tasks;
-using Synology.Api.Client.Apis.FileStation.CopyMove.Models;
-using Synology.Api.Client.Session;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Synology.Api.Client.ApiDescription;
+using Synology.Api.Client.Apis.FileStation.CopyMove.Models;
 using Synology.Api.Client.Extensions;
+using Synology.Api.Client.Session;
 using Synology.Api.Client.Shared.Models;
 
 namespace Synology.Api.Client.Apis.FileStation.CopyMove
@@ -36,30 +37,40 @@ namespace Synology.Api.Client.Apis.FileStation.CopyMove
 
         public Task<FileStationCopyMoveStatusResponse> GetStatusAsync(string taskId)
         {
+            var queryParams = new Dictionary<string, string>
+            {
+                { "taskid",  taskId }
+            };
+
             return _synologyHttpClient.GetAsync<FileStationCopyMoveStatusResponse>(
                 _apiInfo,
                 "status",
-                new { taskid = taskId },
+                queryParams,
                 _session);
         }
 
         public Task<BaseApiResponse> StopAsync(string taskId)
         {
+            var queryParams = new Dictionary<string, string>
+            {
+                { "taskid",  taskId }
+            };
+
             return _synologyHttpClient.GetAsync<BaseApiResponse>(
                 _apiInfo,
                 "stop",
-                new { taskid = taskId },
+                queryParams,
                 _session);
         }
 
-        private object GetCopyMoveQueryParams(string[] paths, string destination, bool overwrite, bool isMoveAction)
+        private Dictionary<string, string> GetCopyMoveQueryParams(string[] paths, string destination, bool overwrite, bool isMoveAction)
         {
-            return new
+            return new Dictionary<string, string>
             {
-                path = paths.ToCommaSeparatedAroundBrackets(),
-                dest_folder_path = destination,
-                overwrite = overwrite.ToLowerString(),
-                remove_src = isMoveAction.ToLowerString()
+                { "path",  paths.ToCommaSeparatedAroundBrackets() },
+                { "dest_folder_path", destination },
+                { "overwrite", overwrite.ToLowerString() },
+                { "remove_src", isMoveAction.ToLowerString() }
             };
         }
     }

--- a/src/Synology.Api.Client/Apis/FileStation/CopyMove/Models/FileStationCopyMoveStartResponse.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/CopyMove/Models/FileStationCopyMoveStartResponse.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.FileStation.CopyMove.Models
 {
     public class FileStationCopyMoveStartResponse
     {
-        [JsonProperty("taskid")]
+        [JsonPropertyName("taskid")]
         public string TaskId { get; set; }
     }
 }

--- a/src/Synology.Api.Client/Apis/FileStation/CopyMove/Models/FileStationCopyMoveStatusResponse.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/CopyMove/Models/FileStationCopyMoveStatusResponse.cs
@@ -1,17 +1,17 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.FileStation.CopyMove.Models
 {
     public class FileStationCopyMoveStatusResponse
     {
-        [JsonProperty("dest_folder_path")]
+        [JsonPropertyName("dest_folder_path")]
         public string DestFolderPath { get; set; }
 
         public bool Finished { get; set; }
 
         public string Path { get; set; }
 
-        [JsonProperty("processed_size")]
+        [JsonPropertyName("processed_size")]
         public decimal ProcessedSize { get; set; }
 
         public decimal Progress { get; set; }

--- a/src/Synology.Api.Client/Apis/FileStation/CreateFolder/FileStationCreateFolderEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/CreateFolder/FileStationCreateFolderEndpoint.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
-using Synology.Api.Client.Apis.FileStation.CreateFolder.Models;
-using Synology.Api.Client.Session;
-using Synology.Api.Client.ApiDescription;
-using Synology.Api.Client.Extensions;
+﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Synology.Api.Client.ApiDescription;
+using Synology.Api.Client.Apis.FileStation.CreateFolder.Models;
+using Synology.Api.Client.Extensions;
+using Synology.Api.Client.Session;
 
 namespace Synology.Api.Client.Apis.FileStation.CreateFolder
 {
@@ -27,17 +28,18 @@ namespace Synology.Api.Client.Apis.FileStation.CreateFolder
             return _synologyHttpClient.GetAsync<FileStationCreateFolderCreateResponse>(_apiInfo, "create", queryParams, _session);
         }
 
-        private object GetCreateQueryParams(string[] paths, bool createParentFolders)
+        private Dictionary<string, string> GetCreateQueryParams(string[] paths, bool createParentFolders)
         {
             var additionalParams = new[] { "real_path", "owner", "time" };
             var folderPaths = paths.Select(p => p.Substring(0, p.LastIndexOf('/')));
             var folderNames = paths.Select(p => p.Substring(p.LastIndexOf('/') + 1));
-            return new
+
+            return new Dictionary<string, string>
             {
-                folder_path = folderPaths.ToCommaSeparatedAroundBrackets(),
-                name = folderNames.ToCommaSeparatedAroundBrackets(),
-                force_parent = createParentFolders,
-                additional = additionalParams.ToCommaSeparatedAroundBrackets()
+                { "folder_path",  folderPaths.ToCommaSeparatedAroundBrackets() },
+                { "name",  folderNames.ToCommaSeparatedAroundBrackets() },
+                { "force_parent",  createParentFolders.ToLowerString() },
+                { "additional",  additionalParams.ToCommaSeparatedAroundBrackets() }
             };
         }
     }

--- a/src/Synology.Api.Client/Apis/FileStation/Extract/FileStationExtractEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/Extract/FileStationExtractEndpoint.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Synology.Api.Client.ApiDescription;
 using Synology.Api.Client.Apis.FileStation.Extract.Models;
 using Synology.Api.Client.Extensions;
@@ -22,13 +23,13 @@ namespace Synology.Api.Client.Apis.FileStation.Extract
 
         public Task<FileStationExtractStartResponse> StartAsync(string filePath, string destination, bool overwrite)
         {
-            var queryParams = new
+            var queryParams = new Dictionary<string, string>
             {
-                file_path = filePath,
-                dest_folder_path = destination,
-                overwrite = overwrite.ToLowerString()
+                { "file_path",  filePath },
+                { "dest_folder_path",  destination },
+                { "overwrite",  overwrite.ToLowerString() }
             };
-            
+
             return _synologyHttpClient.GetAsync<FileStationExtractStartResponse>(
                 _apiInfo,
                 "start",
@@ -38,9 +39,9 @@ namespace Synology.Api.Client.Apis.FileStation.Extract
 
         public Task<FileStationExtractStatusResponse> GetStatusAsync(string taskId)
         {
-            var queryParams = new
+            var queryParams = new Dictionary<string, string>
             {
-                taskid = taskId
+                { "taskid",  taskId }
             };
 
             return _synologyHttpClient.GetAsync<FileStationExtractStatusResponse>(
@@ -52,9 +53,9 @@ namespace Synology.Api.Client.Apis.FileStation.Extract
 
         public Task<BaseApiResponse> StopAsync(string taskId)
         {
-            var queryParams = new
+            var queryParams = new Dictionary<string, string>
             {
-                taskid = taskId
+                { "taskid",  taskId }
             };
 
             return _synologyHttpClient.GetAsync<BaseApiResponse>(_apiInfo, "stop", queryParams, _session);
@@ -62,9 +63,9 @@ namespace Synology.Api.Client.Apis.FileStation.Extract
 
         public Task<FileStationExtractListResponse> ListFilesAsync(string filePath)
         {
-            var queryParams = new
+            var queryParams = new Dictionary<string, string>
             {
-                file_path = filePath
+                { "file_path",  filePath }
             };
 
             return _synologyHttpClient.GetAsync<FileStationExtractListResponse>(

--- a/src/Synology.Api.Client/Apis/FileStation/Extract/Models/FileStationExtractListItem.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/Extract/Models/FileStationExtractListItem.cs
@@ -1,24 +1,24 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.FileStation.Extract.Models
 {
     public class FileStationExtractListItem
     {
-        [JsonProperty("item_id")]
+        [JsonPropertyName("item_id")]
         public int ItemId { get; set; }
 
         public string Name { get; set; }
 
         public decimal Size { get; set; }
 
-        [JsonProperty("pack_size")]
+        [JsonPropertyName("pack_size")]
         public decimal PackSize { get; set; }
 
         public string Mtime { get; set; }
 
         public string Path { get; set; }
 
-        [JsonProperty("is_dir")]
+        [JsonPropertyName("is_dir")]
         public bool IsDir { get; set; }
     }
 }

--- a/src/Synology.Api.Client/Apis/FileStation/Extract/Models/FileStationExtractStartResponse.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/Extract/Models/FileStationExtractStartResponse.cs
@@ -1,17 +1,17 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.FileStation.Extract.Models
 {
     public class FileStationExtractStartResponse
     {
-        [JsonProperty("dest_folder_path")]
+        [JsonPropertyName("dest_folder_path")]
         public string DestFolderPath { get; set; }
 
         public bool Finished { get; set; }
 
         public string Path { get; set; }
 
-        [JsonProperty("processed_size")]
+        [JsonPropertyName("processed_size")]
         public decimal ProcessedSize { get; set; }
 
         public decimal Progress { get; set; }

--- a/src/Synology.Api.Client/Apis/FileStation/Extract/Models/FileStationExtractStatusResponse.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/Extract/Models/FileStationExtractStatusResponse.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.FileStation.Extract.Models
 {
     public class FileStationExtractStatusResponse
     {
-        [JsonProperty("dest_folder_path")]
+        [JsonPropertyName("dest_folder_path")]
         public string DestFolderPath { get; set; }
 
         public bool Finished { get; set; }

--- a/src/Synology.Api.Client/Apis/FileStation/List/FileStationListEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/List/FileStationListEndpoint.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Synology.Api.Client.ApiDescription;
 using Synology.Api.Client.Apis.FileStation.List.Models;
@@ -24,19 +25,19 @@ namespace Synology.Api.Client.Apis.FileStation.List
         {
             var additionalParams = new[] { "real_path", "owner", "time" };
 
-            var queryParams = new
+            var queryParams = new Dictionary<string, string>
             {
-                folder_path = fileStationListRequest.FolderPath,
-                offset = fileStationListRequest.Offset,
-                limit = fileStationListRequest.Limit,
-                sort_by = fileStationListRequest.SortBy ?? FileStationListSortByEnumeration.Name,
-                sort_direction = fileStationListRequest.SortDirection ?? "asc",
-                pattern = fileStationListRequest.Patterns?.Any() == true
+                { "folder_path",  fileStationListRequest.FolderPath },
+                { "offset", fileStationListRequest.Offset.ToString() },
+                { "limit", fileStationListRequest.Limit.ToString() },
+                { "sort_by", fileStationListRequest.SortBy ?? FileStationListSortByEnumeration.Name },
+                { "sort_direction", fileStationListRequest.SortDirection ?? "asc" },
+                { "pattern", fileStationListRequest.Patterns?.Any() == true
                     ? fileStationListRequest.Patterns.ToArray<string>().ToCommaSeparatedAroundBrackets()
-                    : null,
-                filetype = fileStationListRequest.FileType ?? "all",
-                goto_path = fileStationListRequest.GoToPath,
-                additional = additionalParams.ToCommaSeparatedAroundBrackets()
+                    : null },
+                { "filetype", fileStationListRequest.FileType ?? "all" },
+                { "goto_path", fileStationListRequest.GoToPath },
+                { "additional", additionalParams.ToCommaSeparatedAroundBrackets() }
             };
 
             return _synologyHttpClient.GetAsync<FileStationListResponse>(
@@ -50,9 +51,9 @@ namespace Synology.Api.Client.Apis.FileStation.List
         {
             var additionalParams = new[] { "real_path", "owner", "time" };
 
-            var queryParams = new
+            var queryParams = new Dictionary<string, string>
             {
-                additional = additionalParams.ToCommaSeparatedAroundBrackets()
+                { "additional",  additionalParams.ToCommaSeparatedAroundBrackets() }
             };
 
             return _synologyHttpClient.GetAsync<FileStationListShareResponse>(

--- a/src/Synology.Api.Client/Apis/FileStation/List/Models/FileStationListShare.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/List/Models/FileStationListShare.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.FileStation.List.Models
 {
     public class FileStationListShare
     {
-        [JsonProperty("isdir")]
+        [JsonPropertyName("isdir")]
         public bool IsDir { get; set; }
 
         public string Name { get; set; }

--- a/src/Synology.Api.Client/Apis/FileStation/List/Models/FileStationListShareAdditional.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/List/Models/FileStationListShareAdditional.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.FileStation.List.Models
 {
     public class FileStationListShareAdditional
     {
-        [JsonProperty("real_path")]
+        [JsonPropertyName("real_path")]
         public string RealPath { get; set; }
 
         public FileStationListShareOwner Owner { get; set; }

--- a/src/Synology.Api.Client/Apis/FileStation/Search/FileStationSearchEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/Search/FileStationSearchEndpoint.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Synology.Api.Client.ApiDescription;
 using Synology.Api.Client.Apis.FileStation.Search.Models;
@@ -23,12 +24,12 @@ namespace Synology.Api.Client.Apis.FileStation.Search
         /// <inheritdoc />
         public Task<FileStationSearchStartResponse> StartAsync(FileStationSearchStartRequest request)
         {
-            var queryParams = new
+            var queryParams = new Dictionary<string, string>
             {
-                folder_path = $"[\"{request.FolderPath}\"]",
-                recursive = request.Recursive.ToLowerString(),
-                pattern = request.Pattern,
-                extension = request.Extension
+                { "folder_path", $"[\"{request.FolderPath}\"]" },
+                { "recursive", request.Recursive.ToLowerString() },
+                { "pattern", request.Pattern },
+                { "extension", request.Extension },
             };
 
             return _synologyHttpClient.GetAsync<FileStationSearchStartResponse>(
@@ -41,11 +42,11 @@ namespace Synology.Api.Client.Apis.FileStation.Search
         /// <inheritdoc />
         public Task<FileStationSearchListResponse> ListAsync(string taskId, int offset = 0, int limit = -1)
         {
-            var queryParams = new
+            var queryParams = new Dictionary<string, string>
             {
-                taskid = taskId,
-                offset,
-                limit
+                { "taskid", taskId },
+                { "offset", offset.ToString() },
+                { "limit", limit.ToString() }
             };
 
             return _synologyHttpClient.GetAsync<FileStationSearchListResponse>(

--- a/src/Synology.Api.Client/Apis/FileStation/Search/Models/FileStationSearchStartResponse.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/Search/Models/FileStationSearchStartResponse.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Synology.Api.Client.Apis.FileStation.Search.Models
 {
     public class FileStationSearchStartResponse
     {
-        [JsonProperty("taskid")]
+        [JsonPropertyName("taskid")]
         public string TaskId { get; set; }
     }
 }

--- a/src/Synology.Api.Client/Apis/FileStation/Upload/FileStationUploadEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/Upload/FileStationUploadEndpoint.cs
@@ -36,6 +36,16 @@ namespace Synology.Api.Client.Apis.FileStation.Upload
         /// <inheritdoc />
         public Task<FileStationUploadResponse> UploadAsync(string filePath, string destination, bool overwrite)
         {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            if (string.IsNullOrWhiteSpace(destination))
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
             var filename = _fileSystem.Path.GetFileName(filePath);
             var fileStream = _fileSystem.File.OpenRead(filePath);
 
@@ -47,8 +57,22 @@ namespace Synology.Api.Client.Apis.FileStation.Upload
         /// <inheritdoc />
         public Task<FileStationUploadResponse> UploadAsync(byte[] bytes, string filename, string destination, bool overwrite)
         {
-            var memoryStream = new MemoryStream(bytes);
+            if (bytes is null)
+            {
+                throw new ArgumentNullException(nameof(bytes));
+            }
 
+            if (string.IsNullOrWhiteSpace(filename))
+            {
+                throw new ArgumentNullException(nameof(filename));
+            }
+
+            if (string.IsNullOrWhiteSpace(destination))
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            var memoryStream = new MemoryStream(bytes);
             var fileContent = GetFileContent(memoryStream, filename);
 
             return SendRequest(fileContent, destination, overwrite);

--- a/src/Synology.Api.Client/Apis/FileStation/Upload/FileStationUploadEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/Upload/FileStationUploadEndpoint.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Abstractions;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Synology.Api.Client.ApiDescription;
 using Synology.Api.Client.Apis.FileStation.Upload.Models;
@@ -38,7 +39,9 @@ namespace Synology.Api.Client.Apis.FileStation.Upload
             var filename = _fileSystem.Path.GetFileName(filePath);
             var fileStream = _fileSystem.File.OpenRead(filePath);
 
-            return SendRequest(GetFileContent(fileStream, filename), destination, overwrite);
+            var fileContent = GetFileContent(fileStream, filename);
+
+            return SendRequest(fileContent, destination, overwrite);
         }
 
         /// <inheritdoc />
@@ -46,19 +49,24 @@ namespace Synology.Api.Client.Apis.FileStation.Upload
         {
             var memoryStream = new MemoryStream(bytes);
 
-            return SendRequest(GetFileContent(memoryStream, filename), destination, overwrite);
+            var fileContent = GetFileContent(memoryStream, filename);
+
+            return SendRequest(fileContent, destination, overwrite);
         }
 
         private Task<FileStationUploadResponse> SendRequest(StreamContent fileContent, string destination, bool overwrite)
         {
-            string boundaryDelimiter = $"----------{DateTime.Now.Ticks:x}";
+            var boundary = Guid.NewGuid().ToString();
 
-            using (var formData = new MultipartFormDataContent(boundaryDelimiter))
+            using (var formData = new MultipartFormDataContent(boundary))
             {
-                var overwriteValue = overwrite ? "true" : "false";
+                // The request will fail if there are quotes around the boundary value
+                formData.Headers.ContentType = new MediaTypeHeaderValue("multipart/form-data");
+                formData.Headers.ContentType.Parameters.Add(new NameValueHeaderValue("boundary", boundary));
 
+                var overwriteValue = overwrite ? "true" : "false";
                 if (_apiInfo.Version >= 3)
-                { 
+                {
                     overwriteValue = overwrite ? "overwrite" : "skip";
                 }
 
@@ -67,12 +75,11 @@ namespace Synology.Api.Client.Apis.FileStation.Upload
                 formData.Add(GetStringContent("method", "upload"));
                 formData.Add(GetStringContent("path", destination));
                 formData.Add(GetStringContent("overwrite", overwriteValue));
-                formData.Add(fileContent);
+                //formData.Add(GetStringContent("create_parents", "true/false"));
 
-                // Remove quotes from ContentType Header
-                // The request will fail if there are quotes around the boundary value 
-                formData.Headers.Remove("Content-Type");
-                formData.Headers.TryAddWithoutValidation("Content-Type", $"multipart/form-data; boundary={boundaryDelimiter}");
+                //prevent ObjectDisposedException
+                //await fileContent.LoadIntoBufferAsync();
+                formData.Add(fileContent);
 
                 return _synologyHttpClient.PostAsync<FileStationUploadResponse>(_apiInfo, "upload", formData, _session);
             };
@@ -81,15 +88,25 @@ namespace Synology.Api.Client.Apis.FileStation.Upload
         private StringContent GetStringContent(string name, string value)
         {
             var sc = new StringContent(value);
-            sc.Headers.Add("Content-Disposition", $"form-data; name=\"{name}\"");
+            sc.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+            {
+                Name = $"\"{name}\""
+            };
+
+            //the API does not like the "Content-Type" header
             sc.Headers.ContentType = null;
+
             return sc;
         }
 
         private StreamContent GetFileContent(Stream stream, string filename)
         {
             var fileContent = new StreamContent(stream);
-            fileContent.Headers.Add("Content-Disposition", $"form-data; name=\"filename\"; filename=\"{filename}\"");
+            fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+            {
+                Name = "\"filename\"",//"\"file\"" seems also to work
+                FileName = $"\"{filename}\""
+            };
 
             return fileContent;
         }

--- a/src/Synology.Api.Client/Apis/Info/InfoEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/Info/InfoEndpoint.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Synology.Api.Client.ApiDescription;
 using Synology.Api.Client.Apis.Info.Models;
 
@@ -17,7 +18,7 @@ namespace Synology.Api.Client.Apis.Info
 
         public Task<InfoQueryResponse> QueryAsync()
         {
-            return _httpClient.GetAsync<InfoQueryResponse>(_apiInfo, "query", new { query = "all" });
+            return _httpClient.GetAsync<InfoQueryResponse>(_apiInfo, "query", new Dictionary<string, string> { { "query", "all" } });
         }
     }
 }

--- a/src/Synology.Api.Client/Apis/Info/Models/InfoQueryResponse.cs
+++ b/src/Synology.Api.Client/Apis/Info/Models/InfoQueryResponse.cs
@@ -1,89 +1,89 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 using Synology.Api.Client.Constants;
 
 namespace Synology.Api.Client.Apis.Info.Models
 {
     public class InfoQueryResponse
     {
-        [JsonProperty(ApiNames.InfoApiName)]
+        [JsonPropertyName(ApiNames.InfoApiName)]
         public ApiDescription InfoApi { get; set; }
 
-        [JsonProperty(ApiNames.AuthApiName)]
+        [JsonPropertyName(ApiNames.AuthApiName)]
         public ApiDescription AuthApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationInfoApiName)]
+        [JsonPropertyName(ApiNames.FileStationInfoApiName)]
         public ApiDescription FileStationInfoApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationListApiName)]
+        [JsonPropertyName(ApiNames.FileStationListApiName)]
         public ApiDescription FileStationListApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationSearchApiName)]
+        [JsonPropertyName(ApiNames.FileStationSearchApiName)]
         public ApiDescription FileStationSearchApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationVirtualFolderApiName)]
+        [JsonPropertyName(ApiNames.FileStationVirtualFolderApiName)]
         public ApiDescription FileStationVirtualFolderApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationFavoriteApiName)]
+        [JsonPropertyName(ApiNames.FileStationFavoriteApiName)]
         public ApiDescription FileStationFavoriteApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationThumbApiName)]
+        [JsonPropertyName(ApiNames.FileStationThumbApiName)]
         public ApiDescription FileStationThumbApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationDirSizeApiName)]
+        [JsonPropertyName(ApiNames.FileStationDirSizeApiName)]
         public ApiDescription FileStationDirSizeApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationMd5ApiName)]
+        [JsonPropertyName(ApiNames.FileStationMd5ApiName)]
         public ApiDescription FileStationMd5Api { get; set; }
 
-        [JsonProperty(ApiNames.FileStationCheckPermissionApiName)]
+        [JsonPropertyName(ApiNames.FileStationCheckPermissionApiName)]
         public ApiDescription FileStationCheckPermissionApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationUploadApiName)]
+        [JsonPropertyName(ApiNames.FileStationUploadApiName)]
         public ApiDescription FileStationUploadApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationDownloadApiName)]
+        [JsonPropertyName(ApiNames.FileStationDownloadApiName)]
         public ApiDescription FileStationDownloadApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationSharingApiName)]
+        [JsonPropertyName(ApiNames.FileStationSharingApiName)]
         public ApiDescription FileStationSharingApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationCreateFolderApiName)]
+        [JsonPropertyName(ApiNames.FileStationCreateFolderApiName)]
         public ApiDescription FileStationCreateFolderApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationRenameApiName)]
+        [JsonPropertyName(ApiNames.FileStationRenameApiName)]
         public ApiDescription FileStationRenameApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationCopyMoveApiName)]
+        [JsonPropertyName(ApiNames.FileStationCopyMoveApiName)]
         public ApiDescription FileStationCopyMoveApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationDeleteApiName)]
+        [JsonPropertyName(ApiNames.FileStationDeleteApiName)]
         public ApiDescription FileStationDeleteApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationExtractApiName)]
+        [JsonPropertyName(ApiNames.FileStationExtractApiName)]
         public ApiDescription FileStationExtractApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationCompressApiName)]
+        [JsonPropertyName(ApiNames.FileStationCompressApiName)]
         public ApiDescription FileStationCompressApi { get; set; }
 
-        [JsonProperty(ApiNames.FileStationBackgroundTaskApiName)]
+        [JsonPropertyName(ApiNames.FileStationBackgroundTaskApiName)]
         public ApiDescription FileStationBackGroundApi { get; set; }
 
-        [JsonProperty(ApiNames.DownloadStationInfoApiName)]
+        [JsonPropertyName(ApiNames.DownloadStationInfoApiName)]
         public ApiDescription DownloadStationInfoApi { get; set; }
 
-        [JsonProperty(ApiNames.DownloadStationScheduleApiName)]
+        [JsonPropertyName(ApiNames.DownloadStationScheduleApiName)]
         public ApiDescription DownloadStationScheduleApi { get; set; }
 
-        [JsonProperty(ApiNames.DownloadStationTaskApiName)]
+        [JsonPropertyName(ApiNames.DownloadStationTaskApiName)]
         public ApiDescription DownloadStationTaskApi { get; set; }
 
-        [JsonProperty(ApiNames.DownloadStationStatisticApiName)]
+        [JsonPropertyName(ApiNames.DownloadStationStatisticApiName)]
         public ApiDescription DownloadStationStatisticApi { get; set; }
 
-        [JsonProperty(ApiNames.DownloadStationRssSiteApiName)]
+        [JsonPropertyName(ApiNames.DownloadStationRssSiteApiName)]
         public ApiDescription DownloadStationRssSiteApi { get; set; }
 
-        [JsonProperty(ApiNames.DownloadStationRssFeedApiName)]
+        [JsonPropertyName(ApiNames.DownloadStationRssFeedApiName)]
         public ApiDescription DownloadStationRssFeedApi { get; set; }
     }
 }

--- a/src/Synology.Api.Client/ISynologyHttpClient.cs
+++ b/src/Synology.Api.Client/ISynologyHttpClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Synology.Api.Client.ApiDescription;
 using Synology.Api.Client.Session;
@@ -7,7 +8,7 @@ namespace Synology.Api.Client
 {
     public interface ISynologyHttpClient
     {
-        Task<T> GetAsync<T>(IApiInfo apiInfo, string apiMethod, object queryParams, ISynologySession session = null);
+        Task<T> GetAsync<T>(IApiInfo apiInfo, string apiMethod, Dictionary<string, string> queryParams, ISynologySession session = null);
 
         Task<T> PostAsync<T>(IApiInfo apiInfo, string apiMethod, HttpContent content, ISynologySession session = null);
     }

--- a/src/Synology.Api.Client/Synology.Api.Client.csproj
+++ b/src/Synology.Api.Client/Synology.Api.Client.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Authors>Paulo Lemos Neto</Authors>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>0.0.1</Version>
-    <Description>.NET/C# client for the Synology DSM API</Description>
-    <PackageProjectUrl>https://github.com/plneto/Synology.Api.Client</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/plneto/Synology.Api.Client</RepositoryUrl>
-    <RepositoryType>Git</RepositoryType>
-    <PackageTags>synology dsm api client diskstation</PackageTags>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<Authors>Paulo Lemos Neto</Authors>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Version>0.0.1</Version>
+		<Description>.NET/C# client for the Synology DSM API</Description>
+		<PackageProjectUrl>https://github.com/plneto/Synology.Api.Client</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/plneto/Synology.Api.Client</RepositoryUrl>
+		<RepositoryType>Git</RepositoryType>
+		<PackageTags>synology dsm api client diskstation</PackageTags>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Flurl.Http" Version="3.2.4" />
-    <PackageReference Include="System.IO.Abstractions" Version="17.2.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+		<PackageReference Include="System.IO.Abstractions" Version="19.1.14" />
+	</ItemGroup>
 
 </Project>

--- a/src/Synology.Api.Client/Synology.Api.Client.csproj
+++ b/src/Synology.Api.Client/Synology.Api.Client.csproj
@@ -15,7 +15,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
-		<PackageReference Include="System.IO.Abstractions" Version="19.1.14" />
+		<PackageReference Include="System.IO.Abstractions" Version="19.1.18" />
 	</ItemGroup>
 
 </Project>

--- a/src/Synology.Api.Client/SynologyClient.cs
+++ b/src/Synology.Api.Client/SynologyClient.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using System.Security;
 using System.Threading.Tasks;
-using Flurl.Http;
 using Synology.Api.Client.ApiDescription;
 using Synology.Api.Client.Apis.Auth;
 using Synology.Api.Client.Apis.DownloadStation;
@@ -29,14 +28,9 @@ namespace Synology.Api.Client
                 throw new ArgumentNullException(nameof(dsmUrl));
             }
 
-            var flurlClient = new FlurlClient(httpClient)
-            {
-                BaseUrl = $"{dsmUrl.TrimEnd('/')}/webapi"
-            };
+            httpClient.BaseAddress = new Uri($"{dsmUrl.TrimEnd('/')}/webapi");
 
-            flurlClient.AllowAnyHttpStatus();
-
-            _synologyHttpClient = new SynologyHttpClient(flurlClient);
+            _synologyHttpClient = new SynologyHttpClient(httpClient);
 
             UpdateApisInfoAsync().Wait();
         }
@@ -98,7 +92,7 @@ namespace Synology.Api.Client
 
             Session = null;
         }
-        
+
         /// <summary>
         /// Updates the API descriptions using the response from the InfoApi endpoint.
         /// </summary>

--- a/src/Synology.Api.Client/SynologyHttpClient.cs
+++ b/src/Synology.Api.Client/SynologyHttpClient.cs
@@ -36,7 +36,8 @@ namespace Synology.Api.Client
 
         public async Task<T> PostAsync<T>(IApiInfo apiInfo, string apiMethod, HttpContent content, ISynologySession session = null)
         {
-            var uriBuilder = new UriBuilder($"{_httpClient.BaseAddress}/{apiInfo.Path}");
+            var uri = new Uri(_httpClient.BaseAddress, apiInfo.Path);
+            var uriBuilder = new UriBuilder(uri);
 
             if (session != null)
             {

--- a/src/Synology.Api.Client/SynologyHttpClient.cs
+++ b/src/Synology.Api.Client/SynologyHttpClient.cs
@@ -25,7 +25,7 @@ namespace Synology.Api.Client
 
         public async Task<T> GetAsync<T>(IApiInfo apiInfo, string apiMethod, Dictionary<string, string> queryParams, ISynologySession session = null)
         {
-            var uri = new Uri(_httpClient.BaseAddress, apiInfo.Path);
+            var uri = GetBaseUri(_httpClient.BaseAddress, apiInfo.Path);
             var uriBuilder = new UriBuilder(uri);
 
             uriBuilder.Query = BuildQueryString(uriBuilder, apiInfo, apiMethod, queryParams, session);
@@ -36,7 +36,7 @@ namespace Synology.Api.Client
 
         public async Task<T> PostAsync<T>(IApiInfo apiInfo, string apiMethod, HttpContent content, ISynologySession session = null)
         {
-            var uri = new Uri(_httpClient.BaseAddress, apiInfo.Path);
+            var uri = GetBaseUri(_httpClient.BaseAddress, apiInfo.Path);
             var uriBuilder = new UriBuilder(uri);
 
             if (session != null)
@@ -50,6 +50,14 @@ namespace Synology.Api.Client
 
             using var response = await _httpClient.PostAsync(uriBuilder.Uri, content);
             return await HandleSynologyResponse<T>(response, apiInfo, apiMethod);
+        }
+
+        private static Uri GetBaseUri(Uri baseAddress, string apiPath)
+        {
+            var baseUri = baseAddress.ToString().TrimEnd('/');
+            apiPath = apiPath.TrimStart('/');
+
+            return new Uri(baseUri + "/" + apiPath);
         }
 
         private string BuildQueryString(UriBuilder uriBuilder, IApiInfo apiInfo, string apiMethod, Dictionary<string, string> queryParams, ISynologySession session = null)

--- a/src/Synology.Api.Client/SynologyHttpClient.cs
+++ b/src/Synology.Api.Client/SynologyHttpClient.cs
@@ -25,7 +25,9 @@ namespace Synology.Api.Client
 
         public async Task<T> GetAsync<T>(IApiInfo apiInfo, string apiMethod, Dictionary<string, string> queryParams, ISynologySession session = null)
         {
-            var uriBuilder = new UriBuilder($"{_httpClient.BaseAddress}/{apiInfo.Path}");
+            var uri = new Uri(_httpClient.BaseAddress, apiInfo.Path);
+            var uriBuilder = new UriBuilder(uri);
+
             uriBuilder.Query = BuildQueryString(uriBuilder, apiInfo, apiMethod, queryParams, session);
 
             using var response = await _httpClient.GetAsync(uriBuilder.Uri);

--- a/src/Synology.Api.Client/SynologyHttpClient.cs
+++ b/src/Synology.Api.Client/SynologyHttpClient.cs
@@ -44,6 +44,7 @@ namespace Synology.Api.Client
                 uriBuilder.Query = $"_sid={session.Sid}";
             }
 
+            //just for debugging to check values more easily
             //var headersAsString = content.Headers.ToString();
             //var contentAsString = await content.ReadAsStringAsync();
 


### PR DESCRIPTION
This PR is kind of a rewrite to remove the dependencies on `Flurl` and `Newtonsoft.Json`.
Instead `HttpClient` is used directly and serialization is done by `System.Text.Json`.

The tests were also adjusted and extended.

**Maybe There is a breaking change in the API (`ISynologyHttpClient`).** 

If you don't like this kind of PRs: just close/delete it.

closes #8 

