### PR TITLE
Fix exception when DownloadStation is not installed

### DIFF
--- a/src/Synology.Api.Client/ApiDescription/DefaultApisInfo.cs
+++ b/src/Synology.Api.Client/ApiDescription/DefaultApisInfo.cs
@@ -17,17 +17,23 @@ namespace Synology.Api.Client.ApiDescription
         /// <returns>The updated ApisInfo object.</returns>
         public static DefaultApisInfo FromInfoQueryResponse(InfoQueryResponse infoQueryResponse)
         {
-            return new DefaultApisInfo
+            var result = new DefaultApisInfo
             {
                 AuthApi = { Path = infoQueryResponse.AuthApi.Path },
-                DownloadStationTaskApi = { Path = infoQueryResponse.DownloadStationTaskApi.Path },
-                FileStationCopyMoveApi ={ Path = infoQueryResponse.FileStationCopyMoveApi.Path },
+                FileStationCopyMoveApi = { Path = infoQueryResponse.FileStationCopyMoveApi.Path },
                 FileStationCreateFolderApi = { Path = infoQueryResponse.FileStationCreateFolderApi.Path },
                 FileStationExtractApi = { Path = infoQueryResponse.FileStationExtractApi.Path },
                 FileStationListApi = { Path = infoQueryResponse.FileStationListApi.Path },
                 FileStationUploadApi = { Path = infoQueryResponse.FileStationUploadApi.Path },
                 FileStationSearchApi = { Path = infoQueryResponse.FileStationSearchApi.Path },
             };
+
+            if (infoQueryResponse.DownloadStationTaskApi != null)
+            {
+                result.DownloadStationTaskApi.Path = infoQueryResponse.DownloadStationTaskApi.Path;
+            }
+
+            return result;
         }
 
         public IApiInfo InfoApi { get; set; } = new ApiInfo(

--- a/src/Synology.Api.Client/ApiDescription/DefaultApisInfo.cs
+++ b/src/Synology.Api.Client/ApiDescription/DefaultApisInfo.cs
@@ -15,25 +15,19 @@ namespace Synology.Api.Client.ApiDescription
         /// </summary>
         /// <param name="infoQueryResponse">The response from the InfoApi().QueryAsync() method.</param>
         /// <returns>The updated ApisInfo object.</returns>
-        public static DefaultApisInfo FromInfoQueryResponse(InfoQueryResponse infoQueryResponse)
+        public static DefaultApisInfo FromInfoQueryResponse(IApisInfo current, InfoQueryResponse infoQueryResponse)
         {
-            var result = new DefaultApisInfo
+            return new DefaultApisInfo
             {
-                AuthApi = { Path = infoQueryResponse.AuthApi.Path },
-                FileStationCopyMoveApi = { Path = infoQueryResponse.FileStationCopyMoveApi.Path },
-                FileStationCreateFolderApi = { Path = infoQueryResponse.FileStationCreateFolderApi.Path },
-                FileStationExtractApi = { Path = infoQueryResponse.FileStationExtractApi.Path },
-                FileStationListApi = { Path = infoQueryResponse.FileStationListApi.Path },
-                FileStationUploadApi = { Path = infoQueryResponse.FileStationUploadApi.Path },
-                FileStationSearchApi = { Path = infoQueryResponse.FileStationSearchApi.Path },
+                AuthApi = { Path = infoQueryResponse.AuthApi?.Path ?? current.AuthApi.Path },
+                DownloadStationTaskApi = { Path = infoQueryResponse.DownloadStationTaskApi?.Path ?? current.DownloadStationTaskApi.Path },
+                FileStationCopyMoveApi = { Path = infoQueryResponse.FileStationCopyMoveApi?.Path ?? current.FileStationCopyMoveApi.Path },
+                FileStationCreateFolderApi = { Path = infoQueryResponse.FileStationCreateFolderApi?.Path ?? current.FileStationCreateFolderApi.Path },
+                FileStationExtractApi = { Path = infoQueryResponse.FileStationExtractApi?.Path ?? current.FileStationExtractApi.Path },
+                FileStationListApi = { Path = infoQueryResponse.FileStationListApi?.Path ?? current.FileStationListApi.Path },
+                FileStationUploadApi = { Path = infoQueryResponse.FileStationUploadApi?.Path ?? current.FileStationUploadApi.Path },
+                FileStationSearchApi = { Path = infoQueryResponse.FileStationSearchApi?.Path ?? current.FileStationSearchApi.Path },
             };
-
-            if (infoQueryResponse.DownloadStationTaskApi != null)
-            {
-                result.DownloadStationTaskApi.Path = infoQueryResponse.DownloadStationTaskApi.Path;
-            }
-
-            return result;
         }
 
         public IApiInfo InfoApi { get; set; } = new ApiInfo(

--- a/src/Synology.Api.Client/SynologyClient.cs
+++ b/src/Synology.Api.Client/SynologyClient.cs
@@ -98,7 +98,7 @@ namespace Synology.Api.Client
 
             Session = null;
         }
-        
+
         /// <summary>
         /// Updates the API descriptions using the response from the InfoApi endpoint.
         /// </summary>
@@ -106,7 +106,7 @@ namespace Synology.Api.Client
         {
             var infoQueryResponse = await InfoApi().QueryAsync();
 
-            ApisInfo = DefaultApisInfo.FromInfoQueryResponse(infoQueryResponse);
+            ApisInfo = DefaultApisInfo.FromInfoQueryResponse(ApisInfo, infoQueryResponse);
         }
     }
 }


### PR DESCRIPTION
This PR fixes a `NullReferenceException` that was introduced with the latest commit 4ad61905b0985608f8d009c4d1a89a60e60099bd.

The exception was thrown when there was no `DownloadStation` installed/available.

If there is no `DownloadStation` available, the default `Path` will be used (like before).