### PR TITLE
Fix `FileStationListEndpoint().List()` when used with `pattern`

### DIFF
--- a/src/Synology.Api.Client.Integration.Tests/FileStationApiTests.cs
+++ b/src/Synology.Api.Client.Integration.Tests/FileStationApiTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using FluentAssertions;
 using Synology.Api.Client.Apis.FileStation.List.Models;
@@ -39,6 +40,49 @@ namespace Synology.Api.Client.Integration.Tests
             // arrange
             var folderPath = "/shared_folder/dir";
             var request = new FileStationListRequest(folderPath);
+
+            // act
+            var listResponse = await _fixture
+                .Client
+                .FileStationApi()
+                .ListEndpoint()
+                .ListAsync(request);
+
+            // assert
+            listResponse.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void FileStationApi_List_SingleFile_Success()
+        {
+            // arrange
+            var folderPath = "/shared_folder/dir";
+            var request = new FileStationListRequest(folderPath, patterns: new List<string>
+            {
+                "existingFile.txt"
+            });
+
+            // act
+            var listResponse = await _fixture
+                .Client
+                .FileStationApi()
+                .ListEndpoint()
+                .ListAsync(request);
+
+            // assert
+            listResponse.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void FileStationApi_List_MultipleFiles_Success()
+        {
+            // arrange
+            var folderPath = "/shared_folder/dir";
+            var request = new FileStationListRequest(folderPath, patterns: new List<string>
+            {
+                "existingFile.txt",
+                "another_existing_file.md"
+            });
 
             // act
             var listResponse = await _fixture
@@ -220,7 +264,7 @@ namespace Synology.Api.Client.Integration.Tests
                 "/shared_folder/dir/new-dir",
                 "/shared_folder/dir2/new-dir"
             };
-            
+
             // act
             var createFolderResponse = await _fixture
                 .Client
@@ -250,13 +294,13 @@ namespace Synology.Api.Client.Integration.Tests
             // assert
             startSearchResponse.TaskId.Should().NotBeNullOrWhiteSpace();
         }
-        
+
         [Fact]
         public async void FileStation_SearchList_Success()
         {
             // arrange
             var taskId = ""; // TODO: set task id
-            
+
             // act
             var listSearchResponse = await _fixture
                 .Client

--- a/src/Synology.Api.Client/Apis/FileStation/List/FileStationListEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/List/FileStationListEndpoint.cs
@@ -24,6 +24,16 @@ namespace Synology.Api.Client.Apis.FileStation.List
         {
             var additionalParams = new[] { "real_path", "owner", "time" };
 
+            string patternValue = null;
+            if (fileStationListRequest.Patterns?.Count() == 1)
+            {
+                patternValue = fileStationListRequest.Patterns.First();
+            }
+            else if (fileStationListRequest.Patterns?.Count() > 1)
+            {
+                patternValue = string.Join(",", fileStationListRequest.Patterns);
+            }
+
             var queryParams = new
             {
                 folder_path = fileStationListRequest.FolderPath,
@@ -31,9 +41,7 @@ namespace Synology.Api.Client.Apis.FileStation.List
                 limit = fileStationListRequest.Limit,
                 sort_by = fileStationListRequest.SortBy ?? FileStationListSortByEnumeration.Name,
                 sort_direction = fileStationListRequest.SortDirection ?? "asc",
-                pattern = fileStationListRequest.Patterns?.Any() == true
-                    ? fileStationListRequest.Patterns.ToArray<string>().ToCommaSeparatedAroundBrackets()
-                    : null,
+                pattern = patternValue,
                 filetype = fileStationListRequest.FileType ?? "all",
                 goto_path = fileStationListRequest.GoToPath,
                 additional = additionalParams.ToCommaSeparatedAroundBrackets()

--- a/src/Synology.Api.Client/Apis/FileStation/List/FileStationListEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/List/FileStationListEndpoint.cs
@@ -22,7 +22,7 @@ namespace Synology.Api.Client.Apis.FileStation.List
 
         public Task<FileStationListResponse> ListAsync(FileStationListRequest fileStationListRequest)
         {
-            var additionalParams = new[] { "real_path", "owner", "time" };
+            var additionalParams = new[] { "real_path", "owner", "time", "size" };
 
             string patternValue = null;
             if (fileStationListRequest.Patterns?.Count() == 1)

--- a/src/Synology.Api.Client/Apis/FileStation/List/IFileStationListEndpoint.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/List/IFileStationListEndpoint.cs
@@ -5,7 +5,17 @@ namespace Synology.Api.Client.Apis.FileStation.List
 {
     public interface IFileStationListEndpoint
     {
+        /// <summary>
+        /// Enumerate files in a given folder.
+        /// </summary>
+        /// <param name="fileStationListRequest">A <see cref="FileStationListRequest"/></param>
+        /// <returns>Returns <see cref="FileStationListResponse"/></returns>
         Task<FileStationListResponse> ListAsync(FileStationListRequest fileStationListRequest);
+
+        /// <summary>
+        /// List all shared folders, enumerate files in a shared folder, and get detailed file information.
+        /// </summary>
+        /// <returns>Returns <see cref="FileStationListShareResponse"/></returns>
         Task<FileStationListShareResponse> ListSharesAsync();
     }
 }

--- a/src/Synology.Api.Client/Apis/FileStation/List/Models/FileStationListRequest.cs
+++ b/src/Synology.Api.Client/Apis/FileStation/List/Models/FileStationListRequest.cs
@@ -3,53 +3,53 @@ using System.Collections.Generic;
 
 namespace Synology.Api.Client.Apis.FileStation.List.Models
 {
-	public class FileStationListRequest
-	{
+    public class FileStationListRequest
+    {
         /// <summary>
         /// Create a request to enumerate files in a given folder
         /// </summary>
-        /// <param name="folderPath">A listed folder path started with a shared folder</param>
+        /// <param name="folderPath">A listed folder path started with a shared folder.</param>
         /// <param name="offset">Optional. Specify how many files are skipped before beginning to return listed files.</param>
         /// <param name="limit">Optional. Number of files requested. 0 indicates to list all files with a given folder.</param>
         /// <param name="sortBy">Optional. Specify which file information to sort on. See <see cref="FileStationListSortByEnumeration"/>.</param>
         /// <param name="sortDirection">Optional. Specify to sort ascending or to sort descending. Options include: asc: sort ascending. desc: sort descending.</param>
-        /// <param name="patterns">Optional. iven glob pattern(s) to find files whose names and extensions match a case-insensitive glob pattern.</param>
-        /// <param name="fileType">Optional. file": only enumerate regular files; "dir": only enumerate folders; "all" enumerate regular files and folders.</param>
-        /// <param name="goToPath">Optional. Folder path starting with a shared folder.Return all files and sub-folders within folder_path path until goto_path path recursively.</param>
+        /// <param name="patterns">Optional. Given glob pattern(s) to find files whose names and extensions match a case-insensitive glob pattern.</param>
+        /// <param name="fileType">Optional. "file": only enumerate regular files; "dir": only enumerate folders; "all" enumerate regular files and folders.</param>
+        /// <param name="goToPath">Optional. Folder path starting with a shared folder. Return all files and sub-folders within <paramref name="folderPath"/> path until <paramref name="goToPath"/> path recursively.</param>
         /// <exception cref="ArgumentException">Exception thrown when an argument from the request is not valid</exception>
         public FileStationListRequest(
-			string folderPath,
-			int offset = 0,
-			int limit = 0,
-			string sortBy = null,
-			string sortDirection = null,
-			IEnumerable<string> patterns = null,
-			string fileType = null,
-			string goToPath = null)
-		{
+            string folderPath,
+            int offset = 0,
+            int limit = 0,
+            string sortBy = null,
+            string sortDirection = null,
+            IEnumerable<string> patterns = null,
+            string fileType = null,
+            string goToPath = null)
+        {
             if (string.IsNullOrWhiteSpace(folderPath))
             {
-                throw new ArgumentException("FolderPath cannot be null or white space.");
+                throw new ArgumentException("FolderPath cannot be null or whitespace.", nameof(folderPath));
             }
 
             this.FolderPath = folderPath;
-			this.Offset = offset;
-			this.Limit = limit;
-			this.SortBy = sortBy;
-			this.SortDirection = sortDirection;
-			this.Patterns = patterns;
-			this.FileType = fileType;
-			this.GoToPath = goToPath;
-		}
+            this.Offset = offset;
+            this.Limit = limit;
+            this.SortBy = sortBy;
+            this.SortDirection = sortDirection;
+            this.Patterns = patterns;
+            this.FileType = fileType;
+            this.GoToPath = goToPath;
+        }
 
-		public string FolderPath { get; set; }
-		public int Offset { get; set; }
-		public int Limit { get; set; }
-		public string SortBy { get; set; }
-		public string SortDirection { get; set; }
-		public IEnumerable<string> Patterns { get; set; } = new List<string>();
-		public string FileType { get; set; }
-		public string GoToPath { get; set; }
-	}
+        public string FolderPath { get; set; }
+        public int Offset { get; set; }
+        public int Limit { get; set; }
+        public string SortBy { get; set; }
+        public string SortDirection { get; set; }
+        public IEnumerable<string> Patterns { get; set; } = new List<string>();
+        public string FileType { get; set; }
+        public string GoToPath { get; set; }
+    }
 }
 


### PR DESCRIPTION
My DSM 6 and my DSM 7 machines always returned a `502 BadGateway` when I tried to check if a file is present.

The issue is a not correct formatted parameter `pattern`.
The doc says:

> 2. You can use "," to separate multiple glob patterns.

But the lib always encoded the pattern as `["file","secondFile"]` or `["file"]` instead of the correct `file,secondFile` or `file`.

- also fixed/adjusted some doc-comments
- filesize is now returned
