### PR TITLE
Fix a deadlock when running in UI thread

### DIFF
--- a/src/Synology.Api.Client/SynologyClient.cs
+++ b/src/Synology.Api.Client/SynologyClient.cs
@@ -38,7 +38,7 @@ namespace Synology.Api.Client
 
             _synologyHttpClient = new SynologyHttpClient(flurlClient);
 
-            UpdateApisInfoAsync().Wait();
+            Task.Run(() => UpdateApisInfoAsync()).Wait();
         }
 
         public IApisInfo ApisInfo { get; set; } = new DefaultApisInfo();


### PR DESCRIPTION
The current version does produce a deadlock when used in a UI thread. This PR fixes fixes that issue.

I tested this with a WinForms (.NET 4.8 and .NET 7) and a MAUI (.NET 7) app.
When running inside a Console app (.NET 7) everything worked for me.

It is not a nice solution but works.

_More information:_
https://blog.stephencleary.com/2013/01/async-oop-2-constructors.html

_Proper solution:_
Factory pattern

_Used Hack that works:_
https://stackoverflow.com/questions/23048285/call-asynchronous-method-in-constructor#comment55917952_28737702