### PR TITLE
Add additional errors from API to exception

### DIFF
--- a/src/Synology.Api.Client.Tests/SynologyHttpClientTests.cs
+++ b/src/Synology.Api.Client.Tests/SynologyHttpClientTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using Flurl.Http.Testing;
+using Synology.Api.Client.ApiDescription;
+using Synology.Api.Client.Exceptions;
+using Synology.Api.Client.Shared.Models;
+using Synology.Api.Client.Tests.Fixtures;
+using Xunit;
+
+namespace Synology.Api.Client.Tests
+{
+    public class SynologyHttpClientTests : IClassFixture<SynologyFixture>, IDisposable
+    {
+        private readonly SynologyFixture _synologyFixture;
+        private readonly Fixture _fixture;
+        private readonly HttpTest _httpTest;
+        private readonly IApiInfo _fileStationCopyMoveApiInfo;
+
+        public SynologyHttpClientTests(SynologyFixture synologyFixture)
+        {
+            _fixture = new Fixture();
+            _httpTest = new HttpTest();
+            _synologyFixture = synologyFixture;
+            _fileStationCopyMoveApiInfo = _synologyFixture.ApisInfo.FileStationCopyMoveApi;
+        }
+
+        [Fact]
+        public async Task GetAsync_HasAdditionalErrors_ShouldReturnAdditionalErrors()
+        {
+            // Arrange
+            var apiMethod = _fixture.Create<string>();
+            var errorPath = _fixture.Create<string>();
+            var additionalErrorCode = 408;
+
+            var expectedResponse = new BaseApiResponse
+            {
+                Success = false,
+                Error = new Error
+                {
+                    Code = 1002,
+                    Errors = new List<Shared.Models.Errors>
+                    {
+                        new Shared.Models.Errors
+                        {
+                            Code = additionalErrorCode,
+                            Path = errorPath
+                        }
+                    }
+                }
+            };
+
+            _httpTest.RespondWithJson(expectedResponse);
+
+            // Act
+            var synologyApiException = await Assert.ThrowsAsync<SynologyApiException>(() => _synologyFixture.SynologyHttpClient.GetAsync<BaseApiResponse>(_fileStationCopyMoveApiInfo, apiMethod, new { }));
+
+            // Assert
+            synologyApiException.Data.Count.Should().BeGreaterThan(0);
+        }
+
+        public void Dispose()
+        {
+            _httpTest.Dispose();
+        }
+    }
+}

--- a/src/Synology.Api.Client/Shared/Models/Error.cs
+++ b/src/Synology.Api.Client/Shared/Models/Error.cs
@@ -1,7 +1,11 @@
-﻿namespace Synology.Api.Client.Shared.Models
+﻿using System.Collections.Generic;
+
+namespace Synology.Api.Client.Shared.Models
 {
     public class Error
     {
         public int Code { get; set; }
+
+        public IEnumerable<Errors> Errors { get; set; }
     }
 }

--- a/src/Synology.Api.Client/Shared/Models/Errors.cs
+++ b/src/Synology.Api.Client/Shared/Models/Errors.cs
@@ -1,0 +1,9 @@
+﻿namespace Synology.Api.Client.Shared.Models
+{
+    public class Errors
+    {
+        public int Code { get; set; }
+
+        public string Path { get; set; }
+    }
+}

--- a/src/Synology.Api.Client/SynologyHttpClient.cs
+++ b/src/Synology.Api.Client/SynologyHttpClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -87,7 +88,18 @@ namespace Synology.Api.Client
                     {
                         var errorDescription = GetErrorMessage(response?.Error?.Code ?? 0, apiInfo.Name);
 
-                        throw new SynologyApiException(apiInfo, apiMethod, response.Error.Code, errorDescription);
+                        var synologyApiException = new SynologyApiException(apiInfo, apiMethod, response.Error.Code, errorDescription);
+                        //add additional error details if present
+                        if (response?.Error?.Errors?.Any() ?? false)
+                        {
+                            foreach (var curError in response.Error.Errors)
+                            {
+                                var errorMessage = GetErrorMessage(curError.Code, apiInfo.Name);
+                                synologyApiException.Data.Add($"[{curError.Code}] {errorMessage}", curError.Path);
+                            }
+                        }
+
+                        throw synologyApiException;
                     }
 
                     if (typeof(T) == typeof(BaseApiResponse))
@@ -98,7 +110,7 @@ namespace Synology.Api.Client
                     return response.Data;
 
                 default:
-                    throw new UnexpectedResponseStatusException((HttpStatusCode)httpResponse.StatusCode); ;
+                    throw new UnexpectedResponseStatusException((HttpStatusCode)httpResponse.StatusCode);
             }
         }
 


### PR DESCRIPTION
In the documentation for FileStation on page 8 is information about additional possible errors.
With the current API a developer has no chance to get this information.
This PR fixes that by adding additional errors to the [`Data` property of the `SynologyApiException`](https://learn.microsoft.com/en-us/dotnet/api/system.exception.data).

> **Note**
> The documentation says:
> _Each element within `errors` is a JSON-Style Object which contains an error code and other information, **such as a file path or name**._

Example 2 (in the documentation) just uses `path` and I only managed to get `path` while using the `IFileStationCopyMoveEndpoint`.
So there is a chance that there are other parameters (e.g. `name`) that will be lost with this API, but at least the `code` will be present.

<details><summary>Before/After examples</summary>
<p>

#### before

`SynologyApiException.Message`:
The Synology API Request failed.
Error Code: "1002"
Error Description: "An error occurred at the destination. More information in <errors> object"
API: "SYNO.FileStation.CopyMove" 
Method: "start" 
Version: "3"

-> `<errors> object` not available

#### after

`SynologyApiException.Data`:
![grafik](https://user-images.githubusercontent.com/6222752/220323811-3df54ccb-c57f-4835-a439-a94b8761ee51.png)

--> additional errors with `code`, `message` and `path` are available
</p>
</details>


