### PR TITLE
Fix doesn't support netcoreapp2.1 after System.Net.Http.Json version up 

### DIFF
--- a/src/Synology.Api.Client/Synology.Api.Client.csproj
+++ b/src/Synology.Api.Client/Synology.Api.Client.csproj
@@ -14,7 +14,12 @@
 		<PackageTags>synology dsm api client diskstation</PackageTags>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+		<PackageReference Include="System.IO.Abstractions" Version="19.1.18" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
 		<PackageReference Include="System.IO.Abstractions" Version="19.1.18" />
 	</ItemGroup>


### PR DESCRIPTION
Reason: System.Net.Http.Json doesnt supported netstandard2.0 app after version 5.0.0. Discusion: https://github.com/dotnet/runtime/issues/77367
 
To avoid implicit behavior, I downgraded the version for netstandard2.0 only