### PR TITLE
Remove unsupported .NET 6

### DIFF
--- a/src/Synology.Api.Client/Synology.Api.Client.csproj
+++ b/src/Synology.Api.Client/Synology.Api.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
 		<Authors>Paulo Lemos Neto</Authors>
@@ -20,7 +20,7 @@
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
-	
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
@@ -32,22 +32,15 @@
 		<PackageReference Include="System.IO.Abstractions" Version="21.1.7" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="System.Net.Http.Json" Version="6.0.2" />
-		<PackageReference Include="System.Text.Json" Version="6.0.11" />
-		<PackageReference Include="System.Text.Encodings.Web" Version="6.0.1" />
-		<PackageReference Include="System.IO.Abstractions" Version="21.1.7" />
-	</ItemGroup>
-
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 		<PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
 		<PackageReference Include="System.IO.Abstractions" Version="21.1.7" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
-	
+
 </Project>


### PR DESCRIPTION
This PR removes the now unsupported .NET 6.

See this page for supported frameworks: [https://dotnet.microsoft.com/en-us/download/dotnet](https://dotnet.microsoft.com/en-us/download/dotnet)