### PR TITLE
Adjust `Dockerfile` to use .NET 8 base images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-﻿**/.dockerignore
+﻿**/.classpath
+**/.dockerignore
 **/.env
 **/.git
 **/.gitignore
@@ -23,3 +24,8 @@
 **/values.dev.yaml
 LICENSE
 README.md
+!**/.gitignore
+!.git/HEAD
+!.git/config
+!.git/packed-refs
+!.git/refs/heads/**

--- a/samples/Dotnet8Sample/Dockerfile
+++ b/samples/Dotnet8Sample/Dockerfile
@@ -1,17 +1,29 @@
-﻿FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
+﻿# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+# This stage is used when running from VS in fast mode (Default for Debug configuration)
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
+USER $APP_UID
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+
+# This stage is used to build the service project
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["../samples/Dotnet8Sample/Dotnet8Sample.csproj", "../samples/Dotnet8Sample/"]
-RUN dotnet restore "../samples/Dotnet8Sample/Dotnet8Sample.csproj"
+COPY ["Directory.Build.props", "."]
+COPY ["samples/Dotnet8Sample/Dotnet8Sample.csproj", "samples/Dotnet8Sample/"]
+COPY ["src/Synology.Api.Client/Synology.Api.Client.csproj", "src/Synology.Api.Client/"]
+RUN dotnet restore "./samples/Dotnet8Sample/Dotnet8Sample.csproj"
 COPY . .
-WORKDIR "/src/../samples/Dotnet8Sample"
-RUN dotnet build "Dotnet8Sample.csproj" -c Release -o /app/build
+WORKDIR "/src/samples/Dotnet8Sample"
+RUN dotnet build "./Dotnet8Sample.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
+# This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
-RUN dotnet publish "Dotnet8Sample.csproj" -c Release -o /app/publish /p:UseAppHost=false
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./Dotnet8Sample.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
+# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/samples/Dotnet8Sample/Dotnet8Sample.csproj
+++ b/samples/Dotnet8Sample/Dotnet8Sample.csproj
@@ -6,12 +6,17 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <DockerfileContext>..\..</DockerfileContext>
     </PropertyGroup>
 
     <ItemGroup>
-      <Content Include="..\..\src\.dockerignore">
+      <Content Include="..\..\.dockerignore">
         <Link>.dockerignore</Link>
       </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Dotnet8Sample/Program.cs
+++ b/samples/Dotnet8Sample/Program.cs
@@ -21,7 +21,7 @@ const string sharedFolderPath = "/DataVault/Departments/IT";
  * 5. Logout
  */
 
-Console.WriteLine("Starting Synology API Client .NET 7 sample project");
+Console.WriteLine("Starting Synology API Client .NET 8 sample project");
 
 var client = new SynologyClient(dsmUrl);
 

--- a/samples/Dotnet8Sample/Properties/launchSettings.json
+++ b/samples/Dotnet8Sample/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Dotnet8Sample": {
+      "commandName": "Project"
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker"
+    }
+  }
+}


### PR DESCRIPTION
This PR adjusts the `Dockerfile` to .NET 8 and also some console output for the sample app.

The `Dockerfile` was created via context menu in VS 2022 17.13.